### PR TITLE
Switch from formspree to netlify forms

### DIFF
--- a/src/components/EmailModal.jsx
+++ b/src/components/EmailModal.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 
 const EmailModal = () => (
-  <form method="POST" action="https://formspree.io/contact2019@marcmogdanz.de">
+  <form method="POST" name="contact" data-netlify="true">
+    <input type="hidden" name="form-name" value="contact" />
     <div className="field is-horizontal">
       <div className="field-label is-normal">
         <label className="label" htmlFor="nameInput">


### PR DESCRIPTION
Using Formspree the user will always be redirected to the Formspree website and then back to the origin, creates a bad UX imo. Netlify forms abstracts the whole HTML form stuff and parses it on their site while redirecting the user onto a pre-defined success page and makes the submission available in the netlify dashboard