### PR TITLE
Move <title> from index component to Layout component

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -40,6 +40,7 @@ class Layout extends React.Component {
       <>
         <Helmet>
           <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>Marc Mogdanz</title>
         </Helmet>
 
         {!this.state.legalDisclosureModalHidden && (

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelopeOpenText } from "@fortawesome/free-solid-svg-icons";
 import {
@@ -35,10 +34,6 @@ class IndexPage extends React.Component {
     return (
       <>
         <Layout>
-          <Helmet>
-            <title>Marc Mogdanz</title>
-          </Helmet>
-
           {!this.state.emailModalHidden && (
             <Modal title="Contact" closeHandler={() => this.toggleEmailModal()}>
               <EmailModal />


### PR DESCRIPTION
Currently the `<title>` was rendered in the `index.jsx` which is the default page, but not in the `404.jsx` which is the not found page. Both extend the `Layout.jsx` which implements the `<title>` now.

See #12 